### PR TITLE
Separate cxx and ixx languages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,9 @@ Plugins:
 * `br.dev.pedrolamarao.metal.archive`: creates a conventional "main" archive with tasks
 * `br.dev.pedrolamarao.metal.asm`:  adds assembler sources to "main" component (at `src/main/asm`) with tasks
 * `br.dev.pedrolamarao.metal.c`: adds C sources to "main" component (at `src/main/c`) with tasks
-* `br.dev.pedrolamarao.metal.cxx`: adds C++ sources to "main" component  (at `src/main/cxx`) with tasks
+* `br.dev.pedrolamarao.metal.cpp`: adds CPP sources to "main" component  (at `src/main/cxx`) with tasks
+* `br.dev.pedrolamarao.metal.cxx`: adds C++ module implementation sources to "main" component  (at `src/main/cxx`) with tasks
+* `br.dev.pedrolamarao.metal.ixx`: adds C++ module interface sources to "main" component  (at `src/main/cxx`) with tasks
 
 Under construction:
 

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -44,6 +44,10 @@ gradlePlugin {
             id = "br.dev.pedrolamarao.metal.prebuilt"
             implementationClass = "br.dev.pedrolamarao.gradle.metal.base.MetalPrebuiltPlugin"
         }
+        create("ixx") {
+            id = "br.dev.pedrolamarao.metal.ixx"
+            implementationClass = "br.dev.pedrolamarao.gradle.metal.ixx.MetalIxxPlugin"
+        }
     }
 }
 

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -30,7 +30,7 @@ gradlePlugin {
         }
         create("commands") {
             id = "br.dev.pedrolamarao.metal.commands"
-            implementationClass = "br.dev.pedrolamarao.gradle.metal.base.MetalRootPlugin"
+            implementationClass = "br.dev.pedrolamarao.gradle.metal.base.MetalCommandsPlugin"
         }
         create("cpp") {
             id = "br.dev.pedrolamarao.metal.cpp"

--- a/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/cxx/CxxFunctionalTest.java
+++ b/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/cxx/CxxFunctionalTest.java
@@ -99,7 +99,7 @@ public class CxxFunctionalTest
         final var buildGradleKts =
             """
             plugins {
-                id("br.dev.pedrolamarao.metal.cxx")
+                id("br.dev.pedrolamarao.metal.ixx")
             }
             
             metal {
@@ -162,6 +162,7 @@ public class CxxFunctionalTest
             """
             plugins {
                 id("br.dev.pedrolamarao.metal.cxx")
+                id("br.dev.pedrolamarao.metal.ixx")
             }
             
             metal {

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCommandsTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCommandsTask.java
@@ -2,26 +2,22 @@
 
 package br.dev.pedrolamarao.gradle.metal.asm;
 
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class MetalAsmCommandsTask extends MetalAsmCompileBaseTask
 {
     @Input
     public abstract Property<File> getObjectDirectory ();
-
-    @OutputFile
-    public abstract RegularFileProperty getOutputFile ();
 
     static final String template =
     """
@@ -64,7 +60,8 @@ public abstract class MetalAsmCommandsTask extends MetalAsmCompileBaseTask
         });
 
         // aggregate fields
-        try (var writer = Files.newBufferedWriter(getOutputFile().get().getAsFile().toPath(),StandardCharsets.UTF_8)) {
+        final var output = getTargetDirectory().map(it -> it.file("compile_commands.json")).get();
+        try (var writer = Files.newBufferedWriter(output.getAsFile().toPath(),UTF_8)) {
             writer.write("[\n");
             writer.write( String.join(",\n",list) );
             writer.write("]");

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCompileTask.java
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
-import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -19,14 +18,6 @@ import java.util.ArrayList;
 
 public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
 {
-    final WorkerExecutor workerExecutor;
-
-    @Inject
-    public MetalAsmCompileTask (WorkerExecutor workerExecutor)
-    {
-        this.workerExecutor = workerExecutor;
-    }
-
     public interface CompileParameters extends WorkParameters
     {
         DirectoryProperty getBaseDirectory ();
@@ -40,13 +31,8 @@ public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
 
     public static abstract class CompileAction implements WorkAction<CompileParameters>
     {
-        final ExecOperations execOperations;
-
         @Inject
-        public CompileAction (ExecOperations execOperations)
-        {
-            this.execOperations = execOperations;
-        }
+        public abstract ExecOperations getExec ();
 
         @Override
         public void execute ()
@@ -67,7 +53,7 @@ public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
             try
             {
                 Files.createDirectories(outputPath.getParent());
-                execOperations.exec(it -> it.commandLine(compileArgs));
+                getExec().exec(it -> it.commandLine(compileArgs));
             }
             catch (IOException e) { throw new RuntimeException(e); }
         }
@@ -78,7 +64,7 @@ public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
     {
         final var baseDirectory = getProject().getProjectDir();
         final var outputDirectory = getTargetDirectory();
-        final var workers = workerExecutor.noIsolation();
+        final var workers = getWorkers().noIsolation();
 
         // prepare arguments
         final var compileArgs = toCompileArguments(File::toString);

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmCompileTask.java
@@ -2,13 +2,9 @@
 
 package br.dev.pedrolamarao.gradle.metal.asm;
 
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
@@ -24,15 +20,6 @@ import java.util.ArrayList;
 public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
 {
     final WorkerExecutor workerExecutor;
-
-    @OutputDirectory
-    public abstract DirectoryProperty getOutputDirectory ();
-
-    @Internal
-    Provider<Directory> getOutputTargetDirectory ()
-    {
-        return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
-    }
 
     @Inject
     public MetalAsmCompileTask (WorkerExecutor workerExecutor)
@@ -90,7 +77,7 @@ public abstract class MetalAsmCompileTask extends MetalAsmCompileBaseTask
     public void compile ()
     {
         final var baseDirectory = getProject().getProjectDir();
-        final var outputDirectory = getOutputTargetDirectory();
+        final var outputDirectory = getTargetDirectory();
         final var workers = workerExecutor.noIsolation();
 
         // prepare arguments

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmPlugin.java
@@ -31,22 +31,26 @@ public class MetalAsmPlugin implements Plugin<Project>
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        // prepare configuration
+        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/asm".formatted(name));
         final var compileOptions = objects.listProperty(String.class);
         final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
         final var sources = objects.sourceDirectorySet(name,name);
         sources.srcDir(layout.getProjectDirectory().dir("src/%s/asm".formatted(name)));
         final var objectDirectory = layout.getBuildDirectory().dir("obj/%s/asm".formatted(name));
 
+        // register commands database task
         final var commandsTask = tasks.register("commands-%s-asm".formatted(name), MetalAsmCommandsTask.class, task ->
         {
             task.getCompileOptions().set(compileOptions);
             task.getIncludables().from(includables);
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
-            task.getOutputFile().set(layout.getBuildDirectory().file("db/%s/asm/compile_commands.json".formatted(name)));
+            task.getOutputDirectory().set(commandsDirectory);
             task.setSource(sources);
         });
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
 
+        // register compile task
         final var compileTask = tasks.register("compile-%s-asm".formatted(name), MetalAsmCompileTask.class, task ->
         {
             task.getCompileOptions().set(compileOptions);

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalBasePlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalBasePlugin.java
@@ -43,6 +43,24 @@ public class MetalBasePlugin implements Plugin<Project>
             configuration.setVisible(false);
         });
 
+        project.getConfigurations().resolvable(IMPORTABLE_DEPENDENCIES, configuration -> {
+            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.IMPORTABLE));
+            configuration.extendsFrom(nativeImplementation);
+        });
+
+        project.getConfigurations().consumable(MetalBasePlugin.IMPORTABLE_ELEMENTS, configuration -> {
+            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.IMPORTABLE));
+        });
+
+        project.getConfigurations().resolvable(MetalBasePlugin.INCLUDABLE_DEPENDENCIES, configuration -> {
+            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.INCLUDABLE));
+            configuration.extendsFrom(nativeImplementation);
+        });
+
+        project.getConfigurations().consumable(MetalBasePlugin.INCLUDABLE_ELEMENTS, configuration -> {
+            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.INCLUDABLE));
+        });
+
         configurations.resolvable(LINKABLE_DEPENDENCIES, configuration -> {
             configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.LINKABLE));
             configuration.extendsFrom(nativeImplementation.get());

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalBasePlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalBasePlugin.java
@@ -45,7 +45,7 @@ public class MetalBasePlugin implements Plugin<Project>
 
         project.getConfigurations().resolvable(IMPORTABLE_DEPENDENCIES, configuration -> {
             configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.IMPORTABLE));
-            configuration.extendsFrom(nativeImplementation);
+            configuration.extendsFrom(nativeImplementation.get());
         });
 
         project.getConfigurations().consumable(MetalBasePlugin.IMPORTABLE_ELEMENTS, configuration -> {
@@ -54,7 +54,7 @@ public class MetalBasePlugin implements Plugin<Project>
 
         project.getConfigurations().resolvable(MetalBasePlugin.INCLUDABLE_DEPENDENCIES, configuration -> {
             configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.INCLUDABLE));
-            configuration.extendsFrom(nativeImplementation);
+            configuration.extendsFrom(nativeImplementation.get());
         });
 
         project.getConfigurations().consumable(MetalBasePlugin.INCLUDABLE_ELEMENTS, configuration -> {

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCommandsPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCommandsPlugin.java
@@ -32,8 +32,7 @@ public class MetalCommandsPlugin implements Plugin<Project>
                 }
 
                 final var list = new ArrayList<>();
-                commandsDependencies.forEach(file -> {
-                    if (! file.exists()) return;
+                commandsDependencies.getAsFileTree().forEach(file -> {
                     final var parsed = (List<?>) new groovy.json.JsonSlurper().parse(file);
                     list.addAll(parsed);
                 });

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCommandsPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCommandsPlugin.java
@@ -8,7 +8,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MetalRootPlugin implements Plugin<Project>
+public class MetalCommandsPlugin implements Plugin<Project>
 {
     @Override
     public void apply (Project project)
@@ -33,6 +33,7 @@ public class MetalRootPlugin implements Plugin<Project>
 
                 final var list = new ArrayList<>();
                 commandsDependencies.forEach(file -> {
+                    if (! file.exists()) return;
                     final var parsed = (List<?>) new groovy.json.JsonSlurper().parse(file);
                     list.addAll(parsed);
                 });

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCompileTask.java
@@ -7,7 +7,9 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.workers.WorkerExecutor;
 
+import javax.inject.Inject;
 import java.nio.file.Path;
 
 public abstract class MetalCompileTask extends MetalSourceTask
@@ -23,6 +25,9 @@ public abstract class MetalCompileTask extends MetalSourceTask
     {
         return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
     }
+
+    @Inject
+    public abstract WorkerExecutor getWorkers ();
 
     protected static Path toOutputPath (Path base, Path source, Path output, String extension)
     {

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalCompileTask.java
@@ -1,7 +1,12 @@
 package br.dev.pedrolamarao.gradle.metal.base;
 
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
 
 import java.nio.file.Path;
 
@@ -9,6 +14,15 @@ public abstract class MetalCompileTask extends MetalSourceTask
 {
     @Input
     public abstract ListProperty<String> getCompileOptions ();
+
+    @Internal
+    public abstract DirectoryProperty getOutputDirectory ();
+
+    @OutputDirectory
+    public Provider<Directory> getTargetDirectory ()
+    {
+        return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
+    }
 
     protected static Path toOutputPath (Path base, Path source, Path output, String extension)
     {

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalLinkTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalLinkTask.java
@@ -26,7 +26,7 @@ public abstract class MetalLinkTask extends MetalSourceTask
     {
         final var target = getTarget().orElse("default").get();
         final var name = getProject().getName();
-        return getOutputDirectory().map(it -> it.file("%s/%s.lib".formatted(target,name)));
+        return getOutputDirectory().map(it -> it.file("%s/%s.exe".formatted(target,name)));
     }
 
     @Internal

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCommandsTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCommandsTask.java
@@ -2,26 +2,22 @@
 
 package br.dev.pedrolamarao.gradle.metal.c;
 
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class MetalCCommandsTask extends MetalCCompileBaseTask
 {
     @Input
     public abstract Property<File> getObjectDirectory ();
-
-    @OutputFile
-    public abstract RegularFileProperty getOutputFile ();
 
     static final String template =
     """
@@ -64,7 +60,8 @@ public abstract class MetalCCommandsTask extends MetalCCompileBaseTask
         });
 
         // aggregate fields
-        try (var writer = Files.newBufferedWriter(getOutputFile().get().getAsFile().toPath(),StandardCharsets.UTF_8)) {
+        final var output = getTargetDirectory().map(it -> it.file("compile_commands.json")).get();
+        try (var writer = Files.newBufferedWriter(output.getAsFile().toPath(),UTF_8)) {
             writer.write("[\n");
             writer.write( String.join(",\n",list) );
             writer.write("]");

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCompileTask.java
@@ -2,13 +2,9 @@
 
 package br.dev.pedrolamarao.gradle.metal.c;
 
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
@@ -24,15 +20,6 @@ import java.util.ArrayList;
 public abstract class MetalCCompileTask extends MetalCCompileBaseTask
 {
     final WorkerExecutor workerExecutor;
-
-    @OutputDirectory
-    public abstract DirectoryProperty getOutputDirectory ();
-
-    @Internal
-    Provider<Directory> getOutputTargetDirectory ()
-    {
-        return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
-    }
 
     @Inject
     public MetalCCompileTask (WorkerExecutor workerExecutor)
@@ -90,7 +77,7 @@ public abstract class MetalCCompileTask extends MetalCCompileBaseTask
     public void compile ()
     {
         final var baseDirectory = getProject().getProjectDir();
-        final var outputDirectory = getOutputTargetDirectory();
+        final var outputDirectory = getTargetDirectory();
         final var workers = workerExecutor.noIsolation();
 
         // prepare compile args

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCCompileTask.java
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
-import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -19,14 +18,6 @@ import java.util.ArrayList;
 
 public abstract class MetalCCompileTask extends MetalCCompileBaseTask
 {
-    final WorkerExecutor workerExecutor;
-
-    @Inject
-    public MetalCCompileTask (WorkerExecutor workerExecutor)
-    {
-        this.workerExecutor = workerExecutor;
-    }
-
     public interface CompileParameters extends WorkParameters
     {
         DirectoryProperty getBaseDirectory ();
@@ -40,13 +31,8 @@ public abstract class MetalCCompileTask extends MetalCCompileBaseTask
 
     public static abstract class CompileAction implements WorkAction<CompileParameters>
     {
-        final ExecOperations execOperations;
-
         @Inject
-        public CompileAction (ExecOperations execOperations)
-        {
-            this.execOperations = execOperations;
-        }
+        public abstract ExecOperations getExec ();
 
         @Override
         public void execute ()
@@ -67,7 +53,7 @@ public abstract class MetalCCompileTask extends MetalCCompileBaseTask
             try
             {
                 Files.createDirectories(outputPath.getParent());
-                execOperations.exec(it -> it.commandLine(compileArgs));
+                getExec().exec(it -> it.commandLine(compileArgs));
             }
             catch (IOException e) { throw new RuntimeException(e); }
         }
@@ -78,7 +64,7 @@ public abstract class MetalCCompileTask extends MetalCCompileBaseTask
     {
         final var baseDirectory = getProject().getProjectDir();
         final var outputDirectory = getTargetDirectory();
-        final var workers = workerExecutor.noIsolation();
+        final var workers = getWorkers().noIsolation();
 
         // prepare compile args
         final var compileArgs = toCompileArguments(File::toString);

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCPlugin.java
@@ -31,6 +31,7 @@ public class MetalCPlugin implements Plugin<Project>
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/c".formatted(name));
         final var compileOptions = objects.listProperty(String.class);
         final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
         final var sources = objects.sourceDirectorySet(name,name);
@@ -42,7 +43,7 @@ public class MetalCPlugin implements Plugin<Project>
             task.getCompileOptions().set(compileOptions);
             task.getIncludables().from(includables);
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
-            task.getOutputFile().set(layout.getBuildDirectory().file("db/%s/c/compile_commands.json".formatted(name)));
+            task.getOutputDirectory().set(commandsDirectory);
             task.setSource(sources);
         });
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cpp/MetalCppPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cpp/MetalCppPlugin.java
@@ -1,7 +1,6 @@
 package br.dev.pedrolamarao.gradle.metal.cpp;
 
 import br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin;
-import br.dev.pedrolamarao.gradle.metal.base.MetalCapability;
 import br.dev.pedrolamarao.gradle.metal.base.MetalExtension;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -17,21 +16,6 @@ public class MetalCppPlugin implements Plugin<Project>
 
         final var cpp = project.getObjects().domainObjectContainer(MetalCppSources.class, name -> createCppSources(project,name));
         metal.getExtensions().add("cpp", cpp);
-
-        final var nativeImplementation = project.getConfigurations().named("nativeImplementation");
-
-        project.getConfigurations().create(MetalBasePlugin.INCLUDABLE_DEPENDENCIES, configuration -> {
-            configuration.setCanBeConsumed(false);
-            configuration.setCanBeResolved(true);
-            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.INCLUDABLE));
-            configuration.extendsFrom(nativeImplementation.get());
-        });
-
-        project.getConfigurations().create(MetalBasePlugin.INCLUDABLE_ELEMENTS, configuration -> {
-            configuration.setCanBeConsumed(true);
-            configuration.setCanBeResolved(false);
-            configuration.attributes(it -> it.attribute(MetalCapability.ATTRIBUTE, MetalCapability.INCLUDABLE));
-        });
     }
 
     static MetalCppSources createCppSources (Project project, String name)
@@ -44,8 +28,7 @@ public class MetalCppPlugin implements Plugin<Project>
         final var sources = objects.sourceDirectorySet(name,name);
         sources.srcDir( layout.getProjectDirectory().dir("src/%s/cpp".formatted(name)) );
 
-        configurations.named(MetalBasePlugin.INCLUDABLE_ELEMENTS).configure(configuration ->
-        {
+        configurations.named(MetalBasePlugin.INCLUDABLE_ELEMENTS).configure(configuration -> {
             configuration.getOutgoing().artifacts(providers.provider(sources::getSourceDirectories));
         });
 

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCommandsTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCommandsTask.java
@@ -2,26 +2,22 @@
 
 package br.dev.pedrolamarao.gradle.metal.cxx;
 
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class MetalCxxCommandsTask extends MetalCxxCompileBaseTask
 {
     @Input
     public abstract Property<File> getObjectDirectory ();
-
-    @OutputFile
-    public abstract RegularFileProperty getOutputFile ();
 
     static final String template =
     """
@@ -64,7 +60,8 @@ public abstract class MetalCxxCommandsTask extends MetalCxxCompileBaseTask
         });
 
         // aggregate fields
-        try (var writer = Files.newBufferedWriter(getOutputFile().get().getAsFile().toPath(),StandardCharsets.UTF_8)) {
+        final var output = getTargetDirectory().map(it -> it.file("compile_commands.json")).get();
+        try (var writer = Files.newBufferedWriter(output.getAsFile().toPath(),UTF_8)) {
             writer.write("[\n");
             writer.write( String.join(",\n",list) );
             writer.write("]");

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCompileTask.java
@@ -2,13 +2,9 @@
 
 package br.dev.pedrolamarao.gradle.metal.cxx;
 
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
@@ -24,15 +20,6 @@ import java.util.ArrayList;
 public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
 {
     final WorkerExecutor workerExecutor;
-
-    @OutputDirectory
-    public abstract DirectoryProperty getOutputDirectory ();
-
-    @Internal
-    Provider<Directory> getOutputTargetDirectory ()
-    {
-        return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
-    }
 
     @Inject
     public MetalCxxCompileTask (WorkerExecutor workerExecutor)
@@ -90,7 +77,7 @@ public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
     public void compile ()
     {
         final var baseDirectory = getProject().getProjectDir();
-        final var outputDirectory = getOutputTargetDirectory();
+        final var outputDirectory = getTargetDirectory();
         final var queue = workerExecutor.noIsolation();
 
         // prepare arguments

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxCompileTask.java
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
 import org.gradle.workers.WorkParameters;
-import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -19,14 +18,6 @@ import java.util.ArrayList;
 
 public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
 {
-    final WorkerExecutor workerExecutor;
-
-    @Inject
-    public MetalCxxCompileTask (WorkerExecutor workerExecutor)
-    {
-        this.workerExecutor = workerExecutor;
-    }
-
     public interface CompileParameters extends WorkParameters
     {
         DirectoryProperty getBaseDirectory ();
@@ -40,13 +31,8 @@ public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
 
     public static abstract class CompileAction implements WorkAction<CompileParameters>
     {
-        final ExecOperations execOperations;
-
         @Inject
-        public CompileAction (ExecOperations execOperations)
-        {
-            this.execOperations = execOperations;
-        }
+        public abstract ExecOperations getExec ();
 
         @Override
         public void execute ()
@@ -67,7 +53,7 @@ public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
             try
             {
                 Files.createDirectories(outputPath.getParent());
-                execOperations.exec(it -> it.commandLine(compileArgs));
+                getExec().exec(it -> it.commandLine(compileArgs));
             }
             catch (IOException e) { throw new RuntimeException(e); }
         }
@@ -78,7 +64,7 @@ public abstract class MetalCxxCompileTask extends MetalCxxCompileBaseTask
     {
         final var baseDirectory = getProject().getProjectDir();
         final var outputDirectory = getTargetDirectory();
-        final var queue = workerExecutor.noIsolation();
+        final var queue = getWorkers().noIsolation();
 
         // prepare arguments
         final var compileArgs = toCompileArguments(File::toString);

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxPlugin.java
@@ -52,6 +52,7 @@ public class MetalCxxPlugin implements Plugin<Project>
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/cxx".formatted(name));
         final var compileOptions = objects.listProperty(String.class);
         final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
         final var importables = configurations.named(IMPORTABLE_DEPENDENCIES);
@@ -65,7 +66,7 @@ public class MetalCxxPlugin implements Plugin<Project>
             task.getImportables().from(importables);
             task.getIncludables().from(includables);
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
-            task.getOutputFile().set(layout.getBuildDirectory().file("db/%s/cxx/compile_commands.json".formatted(name)));
+            task.getOutputDirectory().set(commandsDirectory);
             task.setSource(sources);
         });
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
@@ -90,6 +91,7 @@ public class MetalCxxPlugin implements Plugin<Project>
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/ixx".formatted(name));
         final var compileOptions = objects.listProperty(String.class);
         final var importables = configurations.named(IMPORTABLE_DEPENDENCIES);
         final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
@@ -103,7 +105,7 @@ public class MetalCxxPlugin implements Plugin<Project>
             task.getIncludables().from(includables);
             task.getImportables().from(importables);
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
-            task.getOutputFile().set(layout.getBuildDirectory().file("db/%s/ixx/compile_commands.json".formatted(name)));
+            task.getOutputDirectory().set(commandsDirectory);
             task.setSource(sources);
         });
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
@@ -117,7 +119,7 @@ public class MetalCxxPlugin implements Plugin<Project>
             task.setSource(sources);
         });
         configurations.named(MetalBasePlugin.IMPORTABLE_ELEMENTS).configure(configuration -> {
-            configuration.getOutgoing().artifact(compileTask.map(MetalIxxCompileTask::getOutputDirectory), it -> it.builtBy(compileTask));
+            configuration.getOutgoing().artifact(compileTask.map(MetalIxxCompileTask::getTargetDirectory), it -> it.builtBy(compileTask));
         });
 
         return new MetalIxxSources(compileOptions, compileTask, name);

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCommandsTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCommandsTask.java
@@ -3,25 +3,21 @@
 package br.dev.pedrolamarao.gradle.metal.ixx;
 
 import br.dev.pedrolamarao.gradle.metal.cxx.MetalCxxCompileBaseTask;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class MetalIxxCommandsTask extends MetalIxxCompileBaseTask
 {
     @Input
     public abstract Property<File> getObjectDirectory ();
-
-    @OutputFile
-    public abstract RegularFileProperty getOutputFile ();
 
     static final String template =
     """
@@ -73,7 +69,8 @@ public abstract class MetalIxxCommandsTask extends MetalIxxCompileBaseTask
         });
 
         // aggregate fields
-        try (var writer = Files.newBufferedWriter(getOutputFile().get().getAsFile().toPath(),StandardCharsets.UTF_8)) {
+        final var output = getTargetDirectory().map(it -> it.file("compile_commands.json")).get();
+        try (var writer = Files.newBufferedWriter(output.getAsFile().toPath(),UTF_8)) {
             writer.write("[\n");
             writer.write( String.join(",\n", commandList) );
             writer.write("]");

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCompileTask.java
@@ -2,12 +2,7 @@
 
 package br.dev.pedrolamarao.gradle.metal.ixx;
 
-import org.gradle.api.file.Directory;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkerExecutor;
@@ -24,15 +19,6 @@ public abstract class MetalIxxCompileTask extends MetalIxxCompileBaseTask
     final ObjectFactory objects;
 
     final WorkerExecutor workers;
-
-    @Internal
-    public abstract DirectoryProperty getOutputDirectory ();
-
-    @OutputDirectory
-    public Provider<Directory> getOutputTargetDirectory ()
-    {
-        return getOutputDirectory().flatMap(it -> it.dir(getTarget().orElse("default")));
-    }
 
     @Inject
     public MetalIxxCompileTask (ExecOperations exec, ObjectFactory objects, WorkerExecutor workers)
@@ -60,7 +46,7 @@ public abstract class MetalIxxCompileTask extends MetalIxxCompileBaseTask
         baseArgs.add("--language=c++-module");
 
         // remove old objects
-        final var outputDirectory = getOutputTargetDirectory().get().getAsFile().toPath();
+        final var outputDirectory = getTargetDirectory().get().getAsFile().toPath();
         getProject().delete(outputDirectory);
 
         // compile objects from sources

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCompileTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxCompileTask.java
@@ -2,32 +2,14 @@
 
 package br.dev.pedrolamarao.gradle.metal.ixx;
 
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.process.ExecOperations;
-import org.gradle.workers.WorkerExecutor;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 
 public abstract class MetalIxxCompileTask extends MetalIxxCompileBaseTask
 {
-    final ExecOperations exec;
-
-    final ObjectFactory objects;
-
-    final WorkerExecutor workers;
-
-    @Inject
-    public MetalIxxCompileTask (ExecOperations exec, ObjectFactory objects, WorkerExecutor workers)
-    {
-        this.exec = exec;
-        this.objects = objects;
-        this.workers = workers;
-    }
-
     @TaskAction
     public void compile () throws ClassNotFoundException, IOException
     {
@@ -61,7 +43,7 @@ public abstract class MetalIxxCompileTask extends MetalIxxCompileBaseTask
             compileArgs.add("--output=%s".formatted(outputPath));
             compileArgs.add(module.source().toString());
 
-            exec.exec(it -> {
+            getProject().exec(it -> {
                 it.commandLine(compileArgs);
             });
         }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxPlugin.java
@@ -1,4 +1,4 @@
-package br.dev.pedrolamarao.gradle.metal.cxx;
+package br.dev.pedrolamarao.gradle.metal.ixx;
 
 import br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin;
 import br.dev.pedrolamarao.gradle.metal.base.MetalExtension;
@@ -9,7 +9,7 @@ import org.gradle.api.file.Directory;
 
 import static br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin.*;
 
-public class MetalCxxPlugin implements Plugin<Project>
+public class MetalIxxPlugin implements Plugin<Project>
 {
     @Override
     public void apply (Project project)
@@ -19,46 +19,48 @@ public class MetalCxxPlugin implements Plugin<Project>
 
         final var metal = project.getExtensions().getByType(MetalExtension.class);
 
-        final var cxx = project.getObjects().domainObjectContainer(MetalCxxSources.class, name -> createSources(project,name));
-        metal.getExtensions().add("cxx", cxx);
+        final var ixx = project.getObjects().domainObjectContainer(MetalIxxSources.class, name -> createSources(project,name));
+        metal.getExtensions().add("ixx", ixx);
     }
 
-    static MetalCxxSources createSources (Project project, String name)
+    static MetalIxxSources createSources (Project project, String name)
     {
         final var configurations = project.getConfigurations();
         final var layout = project.getLayout();
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
-        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/cxx".formatted(name));
+        final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/ixx".formatted(name));
         final var compileOptions = objects.listProperty(String.class);
-        final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
         final var importables = configurations.named(IMPORTABLE_DEPENDENCIES);
+        final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
         final var sources = objects.sourceDirectorySet(name,name);
-        sources.srcDir(layout.getProjectDirectory().dir("src/%s/cxx".formatted(name)));
-        final var objectDirectory = layout.getBuildDirectory().dir("obj/%s/cxx".formatted(name));
+        sources.srcDir(layout.getProjectDirectory().dir("src/%s/ixx".formatted(name)));
+        final var objectDirectory = layout.getBuildDirectory().dir("bmi/%s/ixx".formatted(name));
 
-        final var commandsTask = tasks.register("commands-%s-cxx".formatted(name), MetalCxxCommandsTask.class, task ->
+        final var commandsTask = tasks.register("commands-%s-ixx".formatted(name), MetalIxxCommandsTask.class, task ->
         {
             task.getCompileOptions().set(compileOptions);
-            task.getImportables().from(importables);
             task.getIncludables().from(includables);
+            task.getImportables().from(importables);
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
             task.getOutputDirectory().set(commandsDirectory);
             task.setSource(sources);
         });
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
 
-        final var compileTask = tasks.register("compile-%s-cxx".formatted(name), MetalCxxCompileTask.class, task ->
+        final var compileTask = tasks.register("compile-%s-ixx".formatted(name), MetalIxxCompileTask.class, task ->
         {
             task.getCompileOptions().set(compileOptions);
-            task.getImportables().from(importables);
             task.getIncludables().from(includables);
+            task.getImportables().from(importables);
             task.getOutputDirectory().set(objectDirectory);
             task.setSource(sources);
         });
-        tasks.named("compile").configure(it -> it.dependsOn(compileTask));
+        configurations.named(MetalBasePlugin.IMPORTABLE_ELEMENTS).configure(configuration -> {
+            configuration.getOutgoing().artifact(compileTask.map(MetalIxxCompileTask::getTargetDirectory), it -> it.builtBy(compileTask));
+        });
 
-        return new MetalCxxSources(commandsTask, compileOptions, compileTask, name);
+        return new MetalIxxSources(compileOptions, compileTask, name);
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
@@ -48,6 +48,11 @@ public class MetalIxxSources implements Named
         return compileTask.map(MetalIxxCompileTask::getOutputs);
     }
 
+    public void includable (Object... sources)
+    {
+        compileTask.configure(it -> it.getIncludables().from(sources));
+    }
+
     public void importable (Object... sources)
     {
         compileTask.configure(it -> it.getImportables().from(sources));

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
@@ -40,7 +40,7 @@ public class MetalIxxSources implements Named
 
     public Provider<Directory> getOutputDirectory ()
     {
-        return compileTask.flatMap(MetalIxxCompileTask::getOutputTargetDirectory);
+        return compileTask.flatMap(MetalIxxCompileTask::getTargetDirectory);
     }
 
     public Provider<TaskOutputs> getOutputs ()

--- a/samples/dependency-on-subproject-modules/archive/build.gradle.kts
+++ b/samples/dependency-on-subproject-modules/archive/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("br.dev.pedrolamarao.metal.archive")
     id("br.dev.pedrolamarao.metal.cxx")
+    id("br.dev.pedrolamarao.metal.ixx")
 }
 
 metal {

--- a/samples/dependency-on-subproject-modules/settings.gradle.kts
+++ b/samples/dependency-on-subproject-modules/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         id("br.dev.pedrolamarao.metal.application") version("1.0-SNAPSHOT")
         id("br.dev.pedrolamarao.metal.archive") version("1.0-SNAPSHOT")
         id("br.dev.pedrolamarao.metal.cxx") version("1.0-SNAPSHOT")
+        id("br.dev.pedrolamarao.metal.ixx") version("1.0-SNAPSHOT")
     }
     repositories {
         mavenLocal()
@@ -10,5 +11,6 @@ pluginManagement {
 }
 
 rootProject.name = "sample"
+
 include("application")
 include("archive")

--- a/samples/unconventional-project/README.adoc
+++ b/samples/unconventional-project/README.adoc
@@ -1,11 +1,9 @@
 = unconventional project
 
 This sample demonstrates a project with source directories in a style different from gradle-metal convention.
-An archive is generated from C sources in `lib`.
-An application is generated from C++ sources in `tool`, with an include dependency on CPP headers in `lib` and a link dependency on the archive.
-Object files are expected in `obj`, archives and executables in `bin`.
-The various tasks are registered explicitly.
+There is a limit to how flexible we can be: we accept the user's source layout, but partially impose our build layout.
+The users configures object output to `obj` and assembled outputs to `bin`, but the inner layout is ours.
 
 To build this sample inside a `gradle-metal` source tree, run: `../../gradlew --include-build=../.. build`
 
-Look for the executable file in `application/build/exe`.
+Look for the executable file in `bin`.

--- a/samples/unconventional-project/build.gradle.kts
+++ b/samples/unconventional-project/build.gradle.kts
@@ -22,13 +22,13 @@ val compileTool = tasks.register<MetalCxxCompileTask>("compile-tool") {
 
 // register archive task for lib
 val archiveLib = tasks.register<MetalArchiveTask>("archive-lib") {
-    output = layout.projectDirectory.file("bin/greet.lib")
+    outputDirectory = layout.projectDirectory.dir("bin")
     source( compileLib )
 }
 
 // register link task for lib
 val linkTool = tasks.register<MetalLinkTask>("link-tool") {
-    output = layout.projectDirectory.file("bin/greet.exe")
+    outputDirectory = layout.projectDirectory.dir("bin")
     source( compileTool, archiveLib )
 }
 


### PR DESCRIPTION
This PR separates C++ module implementation and C++ module interfaces as two different languages.
This is a weird thing to do, just as it is already done to the "cpp" preprocessor language.
We are exploring the following effect: the practical difference in compiling C++ normal sources and module implementation sources and C++ module interfaces.
By having explicit C++ module interface source sets, we can compile C++ normal or module implementation sources with not concern for module dependency and ordering, and we may be certain that we *must* resolve module dependency and ordering for C++ module interface source sets.