### PR TITLE
Set linker to clang++

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Validate Gradle Wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Set up JDK 17"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Validate Gradle Wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Set up JDK 17"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Validate Gradle Wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Set up JDK 17"
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Validate Gradle Wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Set up JDK 17"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ on: [pull_request,workflow_dispatch]
 jobs:
   build:
     name: "build"
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 10
     steps:
       - name: "Checkout"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "br.dev.pedrolamarao.gradle.metal"
-version = "0.1-rc-0"
+version = "0.1-rc-1"
 
 subprojects {
     group = rootProject.group

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalLinkTask.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalLinkTask.java
@@ -37,7 +37,7 @@ public abstract class MetalLinkTask extends MetalSourceTask
     {
         return getProviders().gradleProperty("metal.path")
             .orElse(getProviders().environmentVariable("PATH"))
-            .map(it -> Metal.toExecutableFile(it,"clang"));
+            .map(it -> Metal.toExecutableFile(it,"clang++"));
     }
 
     /**


### PR DESCRIPTION
Metal test cases are failing to link in Ubuntu 22.04 for lack of C++ standard libraries.