### PR TITLE
API for set of enabled targets

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,10 +6,12 @@ primarily design to support project link:https://github.com/pedrolamarao/metal[M
 
 Features:
 
-* multiple languages (assembler, c and c++)
-* multiple components (static archives, shared libraries and executables)
-* compile commands database (for clang-check, CLion etc.)
-* dependency on included (sub)project, included build and external prebuilt components
+* compile assembler, c and c++ (including c++ module interfaces)
+* assemble archives and executables
+* build target support (e.g. `x86_64-elf`)
+* generate compilation commands database
+* source dependency on included project
+* binary dependency on prebuilt external project
 * LLVM tools
 
 [WARNING]
@@ -25,7 +27,7 @@ Current requirements:
 
 To use the development version, you may install from source with `./gradlew publishToMavenLocal` and configure your project's settings like this:
 
-[source,kotlin]
+[source]
 ----
 pluginManagement {
     repositories {
@@ -34,7 +36,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id.startsWith("br.dev.pedrolamarao.metal.")) {
-                useModule("br.dev.pedrolamarao.gradle.metal:plugins:[0.2,0.3)")
+                useModule("br.dev.pedrolamarao.gradle.metal:plugins:0.3+")
             }
         }
     }
@@ -45,20 +47,22 @@ Check the link:samples[] for a variety of use-cases.
 
 Plugins:
 
-* `br.dev.pedrolamarao.metal.base`: adds the `metal` extension
-* `br.dev.pedrolamarao.metal.application`: creates a conventional "main" application with tasks
-* `br.dev.pedrolamarao.metal.archive`: creates a conventional "main" archive with tasks
-* `br.dev.pedrolamarao.metal.asm`:  adds assembler sources to "main" component (at `src/main/asm`) with tasks
-* `br.dev.pedrolamarao.metal.c`: adds C sources to "main" component (at `src/main/c`) with tasks
-* `br.dev.pedrolamarao.metal.cpp`: adds CPP sources to "main" component  (at `src/main/cxx`) with tasks
-* `br.dev.pedrolamarao.metal.cxx`: adds C++ module implementation sources to "main" component  (at `src/main/cxx`) with tasks
-* `br.dev.pedrolamarao.metal.ixx`: adds C++ module interface sources to "main" component  (at `src/main/cxx`) with tasks
+* `br.dev.pedrolamarao.metal.base`: adds the Gradle Metal service and extension
+* `br.dev.pedrolamarao.metal.application`: conventional application project
+* `br.dev.pedrolamarao.metal.archive`: conventional archive project
+* `br.dev.pedrolamarao.metal.asm`:  adds assembler source sets
+* `br.dev.pedrolamarao.metal.c`: adds C sources sets
+* `br.dev.pedrolamarao.metal.cpp`: adds C preprocessor source sets
+* `br.dev.pedrolamarao.metal.cxx`: adds C++ module implementation source sets
+* `br.dev.pedrolamarao.metal.ixx`: adds C++ module interface source sets
 
 Under construction:
 
-* dependencies on external cmake project, maven repository
-* GCC and MSVC tools
-* variant flavours (release, debug)
-* variant target machines (any "triple")
+* build flavour support (e.g. `debug`, `release`)
+* shared library component
+* source dependencies on cmake project
+* binary dependencies on maven repository
+* GCC tools
+* MSVC tools
 
 For development status, see Github issues at link:https://github.com/pedrolamarao/gradle-metal/issues[].

--- a/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/application/ApplicationFunctionalTest.java
+++ b/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/application/ApplicationFunctionalTest.java
@@ -70,4 +70,66 @@ public class ApplicationFunctionalTest
             .withProjectDir(projectDir.toFile())
             .build();
     }
+
+    @Test
+    public void languageC () throws IOException
+    {
+        final var languageDir = projectDir.resolve("src/main/c");
+
+        Files.createDirectories(languageDir);
+
+        Files.writeString(languageDir.resolve("main.c"),
+        """
+        int main (int argc, char * argv[])
+        {
+            return 0;
+        }
+        """);
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+             id("br.dev.pedrolamarao.metal.application")
+             id("br.dev.pedrolamarao.metal.c")
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("run-main")
+            .build();
+    }
+
+    @Test
+    public void languageCxx () throws IOException
+    {
+        final var languageDir = projectDir.resolve("src/main/cxx");
+
+        Files.createDirectories(languageDir);
+
+        Files.writeString(languageDir.resolve("main.cxx"),
+    """
+        int main (int argc, char * argv[])
+        {
+            return 0;
+        }
+        """);
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+             id("br.dev.pedrolamarao.metal.application")
+             id("br.dev.pedrolamarao.metal.cxx")
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("run-main")
+            .build();
+    }
 }

--- a/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/asm/AsmFunctionalTest.java
+++ b/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/asm/AsmFunctionalTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AsmFunctionalTest
 {
@@ -47,6 +47,8 @@ public class AsmFunctionalTest
             .withArguments("compile-main-asm")
             .build();
 
+        assertTrue( Files.exists(projectDir.resolve("build/obj")) );
+
         try (var stream = Files.walk(projectDir.resolve("build/obj")).filter(Files::isRegularFile)) {
             assertEquals( 1, stream.count() );
         }
@@ -80,6 +82,87 @@ public class AsmFunctionalTest
             .withProjectDir(projectDir.toFile())
             .withArguments("--quiet","compileOptions")
             .build();
+
         assertEquals("[--foo]",compileOptions.getOutput());
+    }
+
+    @Test
+    public void targetDisabled () throws IOException
+    {
+        Files.createDirectories(projectDir.resolve("src/main/asm"));
+
+        Files.writeString(projectDir.resolve("src/main/asm/bar.s"),
+        """
+        .global foo
+        foo:
+            ret
+        """
+        );
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+            id("br.dev.pedrolamarao.metal.asm")
+        }
+        
+        metal {
+            asm {
+                create("main") {
+                    targets = setOf("i686-elf")
+                }
+            }
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("compile-main-asm","-Pmetal.target=x86_64-elf")
+            .build();
+
+        assertFalse( Files.exists(projectDir.resolve("build/obj")) );
+    }
+
+    @Test
+    public void targetEnabled () throws IOException
+    {
+        Files.createDirectories(projectDir.resolve("src/main/asm"));
+
+        Files.writeString(projectDir.resolve("src/main/asm/bar.s"),
+        """
+        .global foo
+        foo:
+            ret
+        """
+        );
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+            id("br.dev.pedrolamarao.metal.asm")
+        }
+        
+        metal {
+            asm {
+                create("main") {
+                    targets = setOf("i686-elf")
+                }
+            }
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("compile-main-asm","-Pmetal.target=i686-elf")
+            .build();
+
+        assertTrue( Files.exists(projectDir.resolve("build/obj")) );
+
+        try (var stream = Files.walk(projectDir.resolve("build/obj")).filter(Files::isRegularFile)) {
+            assertEquals( 1, stream.count() );
+        }
     }
 }

--- a/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/c/CFunctionalTest.java
+++ b/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/c/CFunctionalTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CFunctionalTest
 {
@@ -49,6 +49,8 @@ public class CFunctionalTest
             .withDebug(true)
             .build();
 
+        assertTrue( Files.exists(projectDir.resolve("build/obj")) );
+
         try (var stream = Files.walk(projectDir.resolve("build/obj")).filter(Files::isRegularFile)) {
             assertEquals( 1, stream.count() );
         }
@@ -82,6 +84,91 @@ public class CFunctionalTest
             .withProjectDir(projectDir.toFile())
             .withArguments("--quiet","compileOptions")
             .build();
+
         assertEquals("[--foo]",compileOptions.getOutput());
+    }
+
+    @Test
+    public void targetDisabled () throws IOException
+    {
+        Files.createDirectories(projectDir.resolve("src/main/c"));
+
+        Files.writeString(projectDir.resolve("src/main/c/main.c"),
+        """
+        int main (int argc, char * argv [])
+        {
+            return 0;
+        }
+        """
+        );
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+            id("br.dev.pedrolamarao.metal.c")
+        }
+        
+        metal {
+            c {
+                create("main") {
+                    targets = setOf("i686-elf")
+                }
+            }
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("compile-main-c","-Pmetal.target=x86_64-elf")
+            .withDebug(true)
+            .build();
+
+        assertFalse( Files.exists(projectDir.resolve("build/obj")) );
+    }
+
+    @Test
+    public void targetEnabled () throws IOException
+    {
+        Files.createDirectories(projectDir.resolve("src/main/c"));
+
+        Files.writeString(projectDir.resolve("src/main/c/main.c"),
+        """
+        int main (int argc, char * argv [])
+        {
+            return 0;
+        }
+        """
+        );
+
+        Files.writeString(projectDir.resolve("build.gradle.kts"),
+        """
+        plugins {
+            id("br.dev.pedrolamarao.metal.c")
+        }
+        
+        metal {
+            c {
+                create("main") {
+                    targets = setOf("i686-elf")
+                }
+            }
+        }
+        """
+        );
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir.toFile())
+            .withArguments("compile-main-c","-Pmetal.target=i686-elf")
+            .withDebug(true)
+            .build();
+
+        assertTrue( Files.exists(projectDir.resolve("build/obj")) );
+
+        try (var stream = Files.walk(projectDir.resolve("build/obj")).filter(Files::isRegularFile)) {
+            assertEquals( 1, stream.count() );
+        }
     }
 }

--- a/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/ixx/IxxFunctionalTest.java
+++ b/plugins/src/functionalTest/java/br/dev/pedrolamarao/gradle/metal/ixx/IxxFunctionalTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IxxFunctionalTest
 {
@@ -56,6 +57,8 @@ public class IxxFunctionalTest
             .withDebug(true)
             .build();
 
+        assertTrue( Files.exists(projectDir.resolve("build/bmi")) );
+
         try (var stream = Files.walk(projectDir.resolve("build/bmi")).filter(Files::isRegularFile)) {
             assertEquals( 1, stream.count() );
         }
@@ -89,6 +92,7 @@ public class IxxFunctionalTest
             .withProjectDir(projectDir.toFile())
             .withArguments("--quiet","compileOptions")
             .build();
+
         assertEquals("[--foo]",compileOptions.getOutput());
     }
 
@@ -145,6 +149,8 @@ public class IxxFunctionalTest
             .withDebug(true)
             .build();
 
+        assertTrue( Files.exists(projectDir.resolve("build/bmi")) );
+
         try (var stream = Files.walk(projectDir.resolve("build/bmi")).filter(Files::isRegularFile)) {
             assertEquals( 3, stream.count() );
         }
@@ -194,7 +200,7 @@ public class IxxFunctionalTest
             ixx {
                 create("main") {
                     compileOptions = listOf("-std=c++20")
-                    includable( cpp.named("main").map { it.sources } )
+                    includes.from( cpp.named("main").map { it.sources } )
                 }
             }
         }
@@ -207,6 +213,8 @@ public class IxxFunctionalTest
             .withArguments("compile-main-ixx")
             .withDebug(true)
             .build();
+
+        assertTrue( Files.exists(projectDir.resolve("build/bmi")) );
 
         try (var stream = Files.walk(projectDir.resolve("build/bmi")).filter(Files::isRegularFile)) {
             assertEquals( 1, stream.count() );

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmPlugin.java
@@ -2,7 +2,6 @@ package br.dev.pedrolamarao.gradle.metal.asm;
 
 import br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin;
 import br.dev.pedrolamarao.gradle.metal.base.MetalExtension;
-import br.dev.pedrolamarao.gradle.metal.cpp.MetalCppPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -33,39 +32,45 @@ public class MetalAsmPlugin implements Plugin<Project>
     {
         final var configurations = project.getConfigurations();
         final var layout = project.getLayout();
-        final var metal = project.getExtensions().findByType(MetalExtension.class);
+        final var metal = project.getExtensions().getByType(MetalExtension.class);
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
-        // prepare configuration
+        final var commandsTask = tasks.register("commands-%s-asm".formatted(name),MetalAsmCommandsTask.class);
+        final var compileTask = tasks.register("compile-%s-asm".formatted(name),MetalAsmCompileTask.class);
+        final var sourceSet = objects.newInstance(MetalAsmSources.class,commandsTask,compileTask,name);
+        sourceSet.getCompileOptions().convention(metal.getCompileOptions());
+        sourceSet.getIncludes().from(configurations.named(INCLUDABLE_DEPENDENCIES));
+        sourceSet.getSources().from(layout.getProjectDirectory().dir("src/%s/asm".formatted(name)));
+        sourceSet.getTargets().convention(metal.getTargets());
+
         final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/asm".formatted(name));
-        final var compileOptions = objects.listProperty(String.class).convention(metal.getCompileOptions());
-        final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
-        final var sources = objects.sourceDirectorySet(name,name);
-        sources.srcDir(layout.getProjectDirectory().dir("src/%s/asm".formatted(name)));
         final var objectDirectory = layout.getBuildDirectory().dir("obj/%s/asm".formatted(name));
 
-        // register commands database task
-        final var commandsTask = tasks.register("commands-%s-asm".formatted(name), MetalAsmCommandsTask.class, task ->
+        commandsTask.configure(task ->
         {
-            task.getCompileOptions().set(compileOptions);
-            task.getIncludables().from(includables);
-            task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
-            task.getOutputDirectory().set(commandsDirectory);
-            task.setSource(sources);
+            task.getCompileOptions().convention(sourceSet.getCompileOptions());
+            task.getIncludables().from(sourceSet.getIncludes());
+            task.getObjectDirectory().convention(objectDirectory.map(Directory::getAsFile));
+            task.getOutputDirectory().convention(commandsDirectory);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
         });
+
+        compileTask.configure(task ->
+        {
+            task.onlyIf(it -> sourceSet.getTargets().zip(task.getTarget(),(targets,target) -> targets.isEmpty() || targets.contains(target)).get());
+            task.getCompileOptions().convention(sourceSet.getCompileOptions());
+            task.getIncludables().from(sourceSet.getSources());
+            task.getOutputDirectory().convention(objectDirectory);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
+        });
+
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
 
-        // register compile task
-        final var compileTask = tasks.register("compile-%s-asm".formatted(name), MetalAsmCompileTask.class, task ->
-        {
-            task.getCompileOptions().set(compileOptions);
-            task.getIncludables().from(includables);
-            task.getOutputDirectory().set(objectDirectory);
-            task.setSource(sources);
-        });
         tasks.named("compile").configure(it -> it.dependsOn(compileTask));
 
-        return new MetalAsmSources(commandsTask, compileOptions, compileTask, name);
+        return sourceSet;
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/asm/MetalAsmSources.java
@@ -1,8 +1,9 @@
 package br.dev.pedrolamarao.gradle.metal.asm;
 
+import br.dev.pedrolamarao.gradle.metal.base.MetalSources;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Named;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskOutputs;
@@ -14,11 +15,9 @@ import javax.inject.Inject;
  * Assembler sources.
  */
 @NonNullApi
-public class MetalAsmSources implements Named
+public abstract class MetalAsmSources extends MetalSources
 {
     private final TaskProvider<MetalAsmCommandsTask> commandsTask;
-
-    private final ListProperty<String> compileOptions;
 
     private final TaskProvider<MetalAsmCompileTask> compileTask;
 
@@ -28,15 +27,13 @@ public class MetalAsmSources implements Named
      * Constructor.
      *
      * @param commandsTask    commands task
-     * @param compileOptions  compile options
      * @param compileTask     compile task
      * @param name            name
      */
     @Inject
-    public MetalAsmSources (TaskProvider<MetalAsmCommandsTask> commandsTask, ListProperty<String> compileOptions, TaskProvider<MetalAsmCompileTask> compileTask, String name)
+    public MetalAsmSources (TaskProvider<MetalAsmCommandsTask> commandsTask, TaskProvider<MetalAsmCompileTask> compileTask, String name)
     {
         this.commandsTask = commandsTask;
-        this.compileOptions = compileOptions;
         this.compileTask = compileTask;
         this.name = name;
     }
@@ -46,10 +43,14 @@ public class MetalAsmSources implements Named
      *
      * @return property
      */
-    public ListProperty<String> getCompileOptions ()
-    {
-        return compileOptions;
-    }
+    public abstract ListProperty<String> getCompileOptions ();
+
+    /**
+     * Preprocessor includes.
+     *
+     * @return collection
+     */
+    public abstract ConfigurableFileCollection getIncludes ();
 
     /**
      * {@inheritDoc}
@@ -70,14 +71,9 @@ public class MetalAsmSources implements Named
         return compileTask.map(DefaultTask::getOutputs);
     }
 
-    /**
-     * Adds directories to include path.
-     *
-     * @param sources  sources to add
-     */
-    public void includable (Object... sources)
+    @Override
+    public String toString ()
     {
-        commandsTask.configure(it -> it.getIncludables().from(sources));
-        compileTask.configure(it -> it.getIncludables().from(sources));
+        return "MetalAsmSources[%s]".formatted(name);
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalApplication.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalApplication.java
@@ -7,16 +7,14 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.TaskProvider;
 
-import javax.annotation.Nonnull;
+import javax.inject.Inject;
 
 /**
  * Metal application component.
  */
 @NonNullApi
-public class MetalApplication extends MetalComponent implements Named
+public abstract class MetalApplication extends MetalComponent implements Named
 {
-    private final ListProperty<String> linkOptions;
-
     private final TaskProvider<MetalLinkTask> linkTask;
 
     private final String name;
@@ -24,13 +22,12 @@ public class MetalApplication extends MetalComponent implements Named
     /**
      * Constructor.
      *
-     * @param linkOptions  link options
      * @param linkTask     link task
      * @param name         name
      */
-    public MetalApplication (ListProperty<String> linkOptions, TaskProvider<MetalLinkTask> linkTask, String name)
+    @Inject
+    public MetalApplication (TaskProvider<MetalLinkTask> linkTask, String name)
     {
-        this.linkOptions = linkOptions;
         this.linkTask = linkTask;
         this.name = name;
     }
@@ -40,18 +37,13 @@ public class MetalApplication extends MetalComponent implements Named
      *
      * @return property
      */
-    @Nonnull
-    public ListProperty<String> getLinkOptions ()
-    {
-        return linkOptions;
-    }
+    public abstract ListProperty<String> getLinkOptions ();
 
     /**
      * Link task.
      *
      * @return provider
      */
-    @Nonnull
     public TaskProvider<MetalLinkTask> getLinkTask ()
     {
         return linkTask;
@@ -64,14 +56,5 @@ public class MetalApplication extends MetalComponent implements Named
     public String getName ()
     {
         return name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void source (Object... sources)
-    {
-        linkTask.configure(it -> it.source(sources));
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalArchive.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalArchive.java
@@ -7,14 +7,14 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.TaskProvider;
 
+import javax.inject.Inject;
+
 /**
  * Metal archive component.
  */
 @NonNullApi
-public class MetalArchive extends MetalComponent implements Named
+public abstract class MetalArchive extends MetalComponent implements Named
 {
-    private final ListProperty<String> archiveOptions;
-
     private final TaskProvider<MetalArchiveTask> archiveTask;
 
     private final String name;
@@ -22,13 +22,12 @@ public class MetalArchive extends MetalComponent implements Named
     /**
      * Constructor.
      *
-     * @param archiveOptions  archive options
      * @param archiveTask     archive task
      * @param name            name
      */
-    public MetalArchive (ListProperty<String> archiveOptions, TaskProvider<MetalArchiveTask> archiveTask, String name)
+    @Inject
+    public MetalArchive (TaskProvider<MetalArchiveTask> archiveTask, String name)
     {
-        this.archiveOptions = archiveOptions;
         this.archiveTask = archiveTask;
         this.name = name;
     }
@@ -38,10 +37,7 @@ public class MetalArchive extends MetalComponent implements Named
      *
      * @return property
      */
-    public ListProperty<String> getArchiveOptions ()
-    {
-        return archiveOptions;
-    }
+    public abstract ListProperty<String> getArchiveOptions ();
 
     /**
      * Archive task.
@@ -60,14 +56,5 @@ public class MetalArchive extends MetalComponent implements Named
     public String getName ()
     {
         return name;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void source (Object... sources)
-    {
-        archiveTask.configure(it -> it.source(sources));
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalComponentPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalComponentPlugin.java
@@ -34,6 +34,7 @@ public abstract class MetalComponentPlugin
             final var metal = project.getExtensions().getByType(MetalExtension.class);
             final var cpp = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("cpp");
             final var sources = (MetalCppSources) cpp.create(name);
+            sources.getTargets().convention(component.getTargets());
             project.getLogger().info("gradle-metal: creating main sources: {}",sources);
         });
 
@@ -44,7 +45,8 @@ public abstract class MetalComponentPlugin
             final var metal = project.getExtensions().getByType(MetalExtension.class);
             final var asm = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("asm");
             final var sources = (MetalAsmSources) asm.create(name);
-            component.source(sources.getOutputs());
+            sources.getTargets().convention(component.getTargets());
+            component.getSources().from(sources.getOutputs());
             project.getLogger().info("gradle-metal: creating main sources: {}",sources);
         });
 
@@ -55,7 +57,8 @@ public abstract class MetalComponentPlugin
             final var metal = project.getExtensions().getByType(MetalExtension.class);
             final var c = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("c");
             final var sources = (MetalCSources) c.create(name);
-            component.source(sources.getOutputs());
+            sources.getTargets().convention(component.getTargets());
+            component.getSources().from(sources.getOutputs());
             project.getLogger().info("gradle-metal: creating main sources: {}",sources);
         });
 
@@ -66,7 +69,8 @@ public abstract class MetalComponentPlugin
             final var metal = project.getExtensions().getByType(MetalExtension.class);
             final var cxx = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("cxx");
             final var sources = (MetalCxxSources) cxx.create(name);
-            component.source(sources.getOutputs());
+            sources.getTargets().convention(component.getTargets());
+            component.getSources().from(sources.getOutputs());
             project.getLogger().info("gradle-metal: creating main sources: {}",sources);
         });
 
@@ -77,6 +81,7 @@ public abstract class MetalComponentPlugin
             final var metal = project.getExtensions().getByType(MetalExtension.class);
             final var ixx = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("ixx");
             final var sources = (MetalIxxSources) ixx.create(name);
+            sources.getTargets().convention(component.getTargets());
             project.getLogger().info("gradle-metal: creating main sources: {}",sources);
         });
 
@@ -93,28 +98,28 @@ public abstract class MetalComponentPlugin
             final var asmContainer = (NamedDomainObjectContainer<?>) metal.getExtensions().findByName("asm");
             if (asmContainer != null) {
                 final var asm = (MetalAsmSources) asmContainer.getByName(name);
-                asm.includable( cpp.getSources() );
+                asm.getIncludes().from( cpp.getSources() );
                 project.getLogger().info("gradle-metal: wiring sources: {} -> {}",cpp,asm);
             }
 
             final var cContainer = (NamedDomainObjectContainer<?>) metal.getExtensions().findByName("c");
             if (cContainer != null) {
                 final var c = (MetalCSources) cContainer.getByName(name);
-                c.includable( cpp.getSources() );
+                c.getIncludes().from( cpp.getSources() );
                 project.getLogger().info("gradle-metal: wiring sources: {} -> {}",cpp,c);
             }
 
             final var cxxContainer = (NamedDomainObjectContainer<?>) metal.getExtensions().findByName("cxx");
             if (cxxContainer != null) {
                 final var cxx = (MetalCxxSources) cxxContainer.getByName(name);
-                cxx.includable( cpp.getSources() );
+                cxx.getIncludes().from( cpp.getSources() );
                 project.getLogger().info("gradle-metal: wiring sources: {} -> {}",cpp,cxx);
             }
 
             final var ixxContainer = (NamedDomainObjectContainer<?>) metal.getExtensions().findByName("ixx");
             if (ixxContainer != null) {
                 final var ixx = (MetalIxxSources) ixxContainer.getByName(name);
-                ixx.includable( cpp.getSources() );
+                ixx.getIncludes().from( cpp.getSources() );
                 project.getLogger().info("gradle-metal: wiring sources: {} -> {}",cpp,ixx);
             }
         });
@@ -132,8 +137,8 @@ public abstract class MetalComponentPlugin
             final var cxxContainer = (NamedDomainObjectContainer<?>) metal.getExtensions().findByName("cxx");
             if (cxxContainer != null) {
                 final var cxx = (MetalCxxSources) cxxContainer.getByName(name);
-                cxx.importable( ixx.getOutputDirectory() );
-                cxx.source( ixx.getOutputs() );
+                cxx.getImports().from( ixx.getOutputDirectory() );
+                cxx.getSources().from( ixx.getOutputs() );
                 project.getLogger().info("gradle-metal: wiring sources: {} -> {}",ixx,cxx);
             }
         });
@@ -157,7 +162,7 @@ public abstract class MetalComponentPlugin
             final var metal = extensions.getByType(MetalExtension.class);
             final var cxx = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("cxx");
             final var dependencyCxx = (MetalCxxSources) cxx.getByName(dependency.getName());
-            dependent.source(dependencyCxx.getOutputs());
+            dependent.getSources().from(dependencyCxx.getOutputs());
             logger.info("gradle-metal: wiring sources: {} -> {}", dependencyCxx, dependent);
         });
 
@@ -167,7 +172,7 @@ public abstract class MetalComponentPlugin
             final var ixx = (NamedDomainObjectContainer<?>) metal.getExtensions().getByName("ixx");
             final var dependentIxx = (MetalIxxSources) ixx.getByName(dependent.getName());
             final var dependencyIxx = (MetalIxxSources) ixx.getByName(dependency.getName());
-            dependentIxx.importable(dependencyIxx.getOutputDirectory());
+            dependentIxx.getImports().from(dependencyIxx.getOutputDirectory());
             logger.info("gradle-metal: wiring sources: {} -> {}", dependencyIxx, dependentIxx);
         });
 
@@ -194,7 +199,7 @@ public abstract class MetalComponentPlugin
                 if (cxx != null) {
                     final var dependentCxx = (MetalCxxSources) cxx.getByName(dependent.getName());
                     final var dependencyIxx = (MetalIxxSources) ixx.getByName(dependency.getName());
-                    dependentCxx.importable( dependencyIxx.getOutputDirectory() );
+                    dependentCxx.getImports().from( dependencyIxx.getOutputDirectory() );
                     // TODO: wire inputs and outputs, not tasks
                     tasks.named("commands-test-cxx").configure(task -> task.dependsOn("compile-main-ixx"));
                     tasks.named("compile-test-cxx").configure(task -> task.dependsOn("compile-main-ixx"));

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalExtension.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalExtension.java
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.services.ServiceReference;
 
 import java.io.File;
@@ -52,6 +53,20 @@ public abstract class MetalExtension implements ExtensionAware
     }
 
     /**
+     * Project-wide link options.
+     *
+     * @return property
+     */
+    public abstract ListProperty<String> getLinkOptions ();
+
+    /**
+     * Tools path.
+     *
+     * @return provider
+     */
+    public Provider<String> getPath () { return getMetalService().map(MetalService::getPath); }
+
+    /**
      * Target name.
      *
      * @return provider
@@ -62,11 +77,11 @@ public abstract class MetalExtension implements ExtensionAware
     }
 
     /**
-     * Project-wide link options.
+     * Set of allowed targets.
      *
-     * @return property
+     * @return set
      */
-    public abstract ListProperty<String> getLinkOptions ();
+    public abstract SetProperty<String> getTargets ();
 
     // methods
 

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalService.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalService.java
@@ -57,7 +57,7 @@ public abstract class MetalService implements BuildService<BuildServiceParameter
     /**
      * Host name.
      *
-     * @return name
+     * @return value
      */
     public String getHost ()
     {
@@ -95,9 +95,16 @@ public abstract class MetalService implements BuildService<BuildServiceParameter
     }
 
     /**
+     * Tools path.
+     *
+     * @return value
+     */
+    public String getPath () { return path; }
+
+    /**
      * Target name.
      *
-     * @return name
+     * @return value
      */
     public String getTarget ()
     {

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/base/MetalSources.java
@@ -5,9 +5,9 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.SetProperty;
 
 /**
- * Gradle Metal component.
+ * Gradle Metal sources.
  */
-public abstract class MetalComponent implements Named
+public abstract class MetalSources implements Named
 {
     /**
      * Source file collection.

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCPlugin.java
@@ -2,7 +2,6 @@ package br.dev.pedrolamarao.gradle.metal.c;
 
 import br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin;
 import br.dev.pedrolamarao.gradle.metal.base.MetalExtension;
-import br.dev.pedrolamarao.gradle.metal.cpp.MetalCppPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -33,36 +32,45 @@ public class MetalCPlugin implements Plugin<Project>
     {
         final var configurations = project.getConfigurations();
         final var layout = project.getLayout();
-        final var metal = project.getExtensions().findByType(MetalExtension.class);
+        final var metal = project.getExtensions().getByType(MetalExtension.class);
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        final var commandsTask = tasks.register("commands-%s-c".formatted(name),MetalCCommandsTask.class);
+        final var compileTask = tasks.register("compile-%s-c".formatted(name),MetalCCompileTask.class);
+        final var sourceSet = objects.newInstance(MetalCSources.class,commandsTask,compileTask,name);
+        sourceSet.getCompileOptions().convention(metal.getCompileOptions());
+        sourceSet.getIncludes().from(configurations.named(INCLUDABLE_DEPENDENCIES));
+        sourceSet.getSources().from(layout.getProjectDirectory().dir("src/%s/c".formatted(name)));
+        sourceSet.getTargets().convention(metal.getTargets());
+
         final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/c".formatted(name));
-        final var compileOptions = objects.listProperty(String.class).convention(metal.getCompileOptions());
-        final var includables = configurations.named(INCLUDABLE_DEPENDENCIES);
-        final var sources = objects.sourceDirectorySet(name,name);
-        sources.srcDir(layout.getProjectDirectory().dir("src/%s/c".formatted(name)));
         final var objectDirectory = layout.getBuildDirectory().dir("obj/%s/c".formatted(name));
 
-        final var commandsTask = tasks.register("commands-%s-c".formatted(name), MetalCCommandsTask.class, task ->
+        commandsTask.configure(task ->
         {
-            task.getCompileOptions().set(compileOptions);
-            task.getIncludables().from(includables);
+            task.getCompileOptions().convention(sourceSet.getCompileOptions());
+            task.getIncludables().from(sourceSet.getIncludes());
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
             task.getOutputDirectory().set(commandsDirectory);
-            task.setSource(sources);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
         });
+
+        compileTask.configure(task ->
+        {
+            task.onlyIf(it -> sourceSet.getTargets().zip(task.getTarget(),(targets,target) -> targets.isEmpty() || targets.contains(target)).get());
+            task.getCompileOptions().convention(sourceSet.getCompileOptions());
+            task.getIncludables().from(sourceSet.getIncludes());
+            task.getOutputDirectory().set(objectDirectory);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
+        });
+
         configurations.named(COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
 
-        final var compileTask = tasks.register("compile-%s-c".formatted(name), MetalCCompileTask.class, task ->
-        {
-            task.getCompileOptions().set(compileOptions);
-            task.getIncludables().from(includables);
-            task.getOutputDirectory().set(objectDirectory);
-            task.setSource(sources);
-        });
         tasks.named("compile").configure(it -> it.dependsOn(compileTask));
 
-        return new MetalCSources(commandsTask, compileOptions, compileTask, name);
+        return sourceSet;
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/c/MetalCSources.java
@@ -1,8 +1,9 @@
 package br.dev.pedrolamarao.gradle.metal.c;
 
+import br.dev.pedrolamarao.gradle.metal.base.MetalSources;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.Named;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskOutputs;
@@ -14,11 +15,9 @@ import javax.inject.Inject;
  * C sources.
  */
 @NonNullApi
-public class MetalCSources implements Named
+public abstract class MetalCSources extends MetalSources
 {
     private final TaskProvider<MetalCCommandsTask> commandsTask;
-
-    private final ListProperty<String> compileOptions;
 
     private final TaskProvider<MetalCCompileTask> compileTask;
 
@@ -28,15 +27,13 @@ public class MetalCSources implements Named
      * Constructor.
      *
      * @param commandsTask    commands task
-     * @param compileOptions  compile options
      * @param compileTask     compile task
      * @param name            name
      */
     @Inject
-    public MetalCSources (TaskProvider<MetalCCommandsTask> commandsTask, ListProperty<String> compileOptions, TaskProvider<MetalCCompileTask> compileTask, String name)
+    public MetalCSources (TaskProvider<MetalCCommandsTask> commandsTask, TaskProvider<MetalCCompileTask> compileTask, String name)
     {
         this.commandsTask = commandsTask;
-        this.compileOptions = compileOptions;
         this.compileTask = compileTask;
         this.name = name;
     }
@@ -46,10 +43,14 @@ public class MetalCSources implements Named
      *
      * @return property
      */
-    public ListProperty<String> getCompileOptions ()
-    {
-        return compileOptions;
-    }
+    public abstract ListProperty<String> getCompileOptions ();
+
+    /**
+     * Preprocessor includes.
+     *
+     * @return collection
+     */
+    public abstract ConfigurableFileCollection getIncludes ();
 
     /**
      * Sources name.
@@ -72,14 +73,9 @@ public class MetalCSources implements Named
         return compileTask.map(DefaultTask::getOutputs);
     }
 
-    /**
-     * Adds directories to the include path.
-     *
-     * @param sources  sources to add
-     */
-    public void includable (Object... sources)
+    @Override
+    public String toString ()
     {
-        commandsTask.configure(it -> it.getIncludables().from(sources));
-        compileTask.configure(it -> it.getIncludables().from(sources));
+        return "MetalCSources[%s]".formatted(name);
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cpp/MetalCppSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cpp/MetalCppSources.java
@@ -1,10 +1,7 @@
 package br.dev.pedrolamarao.gradle.metal.cpp;
 
-import org.gradle.api.Named;
+import br.dev.pedrolamarao.gradle.metal.base.MetalSources;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
-import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.provider.Property;
 
 import javax.inject.Inject;
@@ -12,7 +9,7 @@ import javax.inject.Inject;
 /**
  * C preprocessor sources.
  */
-public abstract class MetalCppSources implements Named
+public abstract class MetalCppSources extends MetalSources
 {
     private final String name;
 
@@ -55,6 +52,6 @@ public abstract class MetalCppSources implements Named
     @Override
     public String toString ()
     {
-        return "MetalCppSourceSet[%s]".formatted(name);
+        return "MetalCppSources[%s]".formatted(name);
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxPlugin.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxPlugin.java
@@ -3,10 +3,12 @@ package br.dev.pedrolamarao.gradle.metal.cxx;
 import br.dev.pedrolamarao.gradle.metal.base.Metal;
 import br.dev.pedrolamarao.gradle.metal.base.MetalBasePlugin;
 import br.dev.pedrolamarao.gradle.metal.base.MetalExtension;
-import br.dev.pedrolamarao.gradle.metal.cpp.MetalCppPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
+
+import static br.dev.pedrolamarao.gradle.metal.base.Metal.IMPORTABLE_DEPENDENCIES;
+import static br.dev.pedrolamarao.gradle.metal.base.Metal.INCLUDABLE_DEPENDENCIES;
 
 /**
  * C++ language support plugin.
@@ -31,39 +33,48 @@ public class MetalCxxPlugin implements Plugin<Project>
     {
         final var configurations = project.getConfigurations();
         final var layout = project.getLayout();
-        final var metal = project.getExtensions().findByType(MetalExtension.class);
+        final var metal = project.getExtensions().getByType(MetalExtension.class);
         final var objects = project.getObjects();
         final var tasks = project.getTasks();
 
+        final var commandsTask = tasks.register("commands-%s-cxx".formatted(name),MetalCxxCommandsTask.class);
+        final var compileTask = tasks.register("compile-%s-cxx".formatted(name),MetalCxxCompileTask.class);
+        final var sourceSet = objects.newInstance(MetalCxxSources.class,commandsTask,compileTask,name);
+        sourceSet.getCompileOptions().convention(metal.getCompileOptions());
+        sourceSet.getImports().from(configurations.named(IMPORTABLE_DEPENDENCIES));
+        sourceSet.getIncludes().from(configurations.named(INCLUDABLE_DEPENDENCIES));
+        sourceSet.getSources().from(layout.getProjectDirectory().dir("src/%s/cxx".formatted(name)));
+        sourceSet.getTargets().convention(metal.getTargets());
+
         final var commandsDirectory = layout.getBuildDirectory().dir("db/%s/cxx".formatted(name));
-        final var compileOptions = objects.listProperty(String.class).convention(metal.getCompileOptions());
-        final var includables = configurations.named(Metal.INCLUDABLE_DEPENDENCIES);
-        final var importables = configurations.named(Metal.IMPORTABLE_DEPENDENCIES);
-        final var sources = objects.sourceDirectorySet(name,name);
-        sources.srcDir(layout.getProjectDirectory().dir("src/%s/cxx".formatted(name)));
         final var objectDirectory = layout.getBuildDirectory().dir("obj/%s/cxx".formatted(name));
 
-        final var commandsTask = tasks.register("commands-%s-cxx".formatted(name), MetalCxxCommandsTask.class, task ->
+        commandsTask.configure(task ->
         {
-            task.getCompileOptions().set(compileOptions);
-            task.getImportables().from(importables);
-            task.getIncludables().from(includables);
+            task.getCompileOptions().set(sourceSet.getCompileOptions());
+            task.getImportables().from(sourceSet.getImports());
+            task.getIncludables().from(sourceSet.getIncludes());
             task.getObjectDirectory().set(objectDirectory.map(Directory::getAsFile));
             task.getOutputDirectory().set(commandsDirectory);
-            task.setSource(sources);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
         });
+
+        compileTask.configure(task ->
+        {
+            task.onlyIf(it -> sourceSet.getTargets().zip(task.getTarget(),(targets,target) -> targets.isEmpty() || targets.contains(target)).get());
+            task.getCompileOptions().set(sourceSet.getCompileOptions());
+            task.getImportables().from(sourceSet.getImports());
+            task.getIncludables().from(sourceSet.getIncludes());
+            task.getOutputDirectory().set(objectDirectory);
+            task.setSource(sourceSet.getSources());
+            task.getTarget().convention(metal.getTarget());
+        });
+
         configurations.named(Metal.COMMANDS_ELEMENTS).configure(it -> it.getOutgoing().artifact(commandsTask));
 
-        final var compileTask = tasks.register("compile-%s-cxx".formatted(name), MetalCxxCompileTask.class, task ->
-        {
-            task.getCompileOptions().set(compileOptions);
-            task.getImportables().from(importables);
-            task.getIncludables().from(includables);
-            task.getOutputDirectory().set(objectDirectory);
-            task.setSource(sources);
-        });
         tasks.named("compile").configure(it -> it.dependsOn(compileTask));
 
-        return new MetalCxxSources(commandsTask, compileOptions, compileTask, name);
+        return sourceSet;
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/cxx/MetalCxxSources.java
@@ -1,7 +1,8 @@
 package br.dev.pedrolamarao.gradle.metal.cxx;
 
-import org.gradle.api.Named;
+import br.dev.pedrolamarao.gradle.metal.base.MetalSources;
 import org.gradle.api.NonNullApi;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskOutputs;
@@ -13,11 +14,9 @@ import javax.inject.Inject;
  * C++ sources.
  */
 @NonNullApi
-public class MetalCxxSources implements Named
+public abstract class MetalCxxSources extends MetalSources
 {
     private final TaskProvider<MetalCxxCommandsTask> commandsTask;
-
-    private final ListProperty<String> compileOptions;
 
     private final TaskProvider<MetalCxxCompileTask> compileTask;
 
@@ -27,15 +26,13 @@ public class MetalCxxSources implements Named
      * Constructor.
      *
      * @param commandsTask    commands task
-     * @param compileOptions  compile options
      * @param compileTask     compile task
      * @param name            name
      */
     @Inject
-    public MetalCxxSources (TaskProvider<MetalCxxCommandsTask> commandsTask, ListProperty<String> compileOptions, TaskProvider<MetalCxxCompileTask> compileTask, String name)
+    public MetalCxxSources (TaskProvider<MetalCxxCommandsTask> commandsTask, TaskProvider<MetalCxxCompileTask> compileTask, String name)
     {
         this.commandsTask = commandsTask;
-        this.compileOptions = compileOptions;
         this.compileTask = compileTask;
         this.name = name;
     }
@@ -45,10 +42,21 @@ public class MetalCxxSources implements Named
      *
      * @return property
      */
-    public ListProperty<String> getCompileOptions ()
-    {
-        return compileOptions;
-    }
+    public abstract ListProperty<String> getCompileOptions ();
+
+    /**
+     * Preprocessor includes.
+     *
+     * @return collection
+     */
+    public abstract ConfigurableFileCollection getIncludes ();
+
+    /**
+     * C++ imports.
+     *
+     * @return collection
+     */
+    public abstract ConfigurableFileCollection getImports ();
 
     /**
      * {@inheritDoc}
@@ -69,36 +77,9 @@ public class MetalCxxSources implements Named
         return compileTask.map(MetalCxxCompileTask::getOutputs);
     }
 
-    /**
-     * Adds directories to the import path.
-     *
-     * @param sources sources to add
-     */
-    public void importable (Object... sources)
+    @Override
+    public String toString ()
     {
-        commandsTask.configure(it -> it.getImportables().from(sources));
-        compileTask.configure(it -> it.getImportables().from(sources));
-    }
-
-    /**
-     * Adds directories to the include path.
-     *
-     * @param sources sources to add
-     */
-    public void includable (Object... sources)
-    {
-        commandsTask.configure(it -> it.getIncludables().from(sources));
-        compileTask.configure(it -> it.getIncludables().from(sources));
-    }
-
-    /**
-     * Adds sources to compilation.
-     *
-     * @param sources sources to add
-     */
-    public void source (Object... sources)
-    {
-        commandsTask.configure(it -> it.source(sources));
-        compileTask.configure(it -> it.source(sources));
+        return "MetalCxxSources[%s]".formatted(name);
     }
 }

--- a/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
+++ b/plugins/src/main/java/br/dev/pedrolamarao/gradle/metal/ixx/MetalIxxSources.java
@@ -1,6 +1,6 @@
 package br.dev.pedrolamarao.gradle.metal.ixx;
 
-import org.gradle.api.Named;
+import br.dev.pedrolamarao.gradle.metal.base.MetalSources;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
@@ -16,7 +16,7 @@ import javax.inject.Inject;
  * C++ module implementation sources.
  */
 @NonNullApi
-public abstract class MetalIxxSources implements Named
+public abstract class MetalIxxSources extends MetalSources
 {
     private final TaskProvider<MetalIxxCompileTask> compileTask;
 
@@ -94,36 +94,9 @@ public abstract class MetalIxxSources implements Named
      */
     public abstract Property<Boolean> getPublic ();
 
-    /**
-     * Source directory set.
-     *
-     * @return value
-     */
-    public abstract ConfigurableFileCollection getSources ();
-
-    /**
-     * Adds directories to the include path.
-     * .
-     * @param sources  sources to add
-     */
-    public void includable (Object... sources)
-    {
-        getIncludes().from(sources);
-    }
-
-    /**
-     * Adds directories to the import path.
-     *
-     * @param sources  sources to add
-     */
-    public void importable (Object... sources)
-    {
-        getImports().from(sources);
-    }
-
     @Override
     public String toString ()
     {
-        return "MetalIxxSourceSet[%s]".formatted(name);
+        return "MetalIxxSources[%s]".formatted(name);
     }
 }


### PR DESCRIPTION
Provide API for restricting the set of targets where the source set or component is enabled.

The empty set has the special meaning of permitting everything.